### PR TITLE
Fix imagemagick download step

### DIFF
--- a/ansible-playbooks/skyplan/roles/download_imagemagick/tasks/main.yml
+++ b/ansible-playbooks/skyplan/roles/download_imagemagick/tasks/main.yml
@@ -25,14 +25,14 @@
 # 🧪 Check if ImageMagick is already installed
 - name: Check if ImageMagick is installed
   command: magick -version
-  register: imagemagick_version
+  register: imagemagick_version_check
   changed_when: false
   failed_when: false
 
 - name: Set skip flag if ImageMagick is installed and version is sufficient
   set_fact:
-    imagemagick_skip_install: "{{ imagemagick_version.stdout is search('ImageMagick') }}"
-  when: imagemagick_version.rc == 0
+    imagemagick_skip_install: "{{ imagemagick_version_check.stdout is search('ImageMagick') }}"
+  when: imagemagick_version_check.rc == 0
 
 - name: Set default skip flag if not already defined
   set_fact:


### PR DESCRIPTION
The ImageMagick download step failed because one of the fact names was re-used as a register for the ImageMagick version check. I renamed the version check register so that it wouldn't conflict, and now it seems to work.