### PR TITLE
Add gopls, dlv, and staticcheck to installed tools

### DIFF
--- a/ansible-playbooks/skyplan/roles/download_go_tools/tasks/main.yml
+++ b/ansible-playbooks/skyplan/roles/download_go_tools/tasks/main.yml
@@ -20,6 +20,8 @@
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.32.0
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
     go install github.com/cosmtrek/air@v1.42.0
+    # These are the latest versions of gopls, dlv, and staticcheck which work with Go 1.20.
+    # Update these to @latest once the product has moved to a supported version of Go.
     go install golang.org/x/tools/gopls@v0.15.3
     go install github.com/go-delve/delve/cmd/dlv@v1.22.1
     go install honnef.co/go/tools/cmd/staticcheck@v0.4.7

--- a/ansible-playbooks/skyplan/roles/download_go_tools/tasks/main.yml
+++ b/ansible-playbooks/skyplan/roles/download_go_tools/tasks/main.yml
@@ -20,6 +20,9 @@
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.32.0
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
     go install github.com/cosmtrek/air@v1.42.0
+    go install golang.org/x/tools/gopls@v0.15.3
+    go install github.com/go-delve/delve/cmd/dlv@v1.22.1
+    go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
   args:
     chdir: "{{ go_project_path }}"
     executable: /bin/zsh


### PR DESCRIPTION
This PR adds gopls (the language server), dlv (the debugger), and staticcheck (the linter) to the `install_go_tools` role. It specifically chooses the last versions of these tools which are compatible with Go 1.20, since that's the Go version in use currently.

Installing compatible versions of these tools automatically will spare future hires from having to dig through the version history of various repositories to try to figure out how to get their editor to run the language server or debugger.